### PR TITLE
Fix 2 Small Issues

### DIFF
--- a/include/gbafe/text.h
+++ b/include/gbafe/text.h
@@ -29,7 +29,7 @@ struct TextHandle {
 	/* 00 */ u16 tileIndexOffset;
 
 	/* 02 */ u8 xCursor;
-	/* 03 */ u8 colotId;
+	/* 03 */ u8 colorId;
 	
 	/* 04 */ u8 tileWidth;
 

--- a/include/gbafe/unit.h
+++ b/include/gbafe/unit.h
@@ -200,13 +200,13 @@ struct UnitDefinition {
 	/* 03 */ u8  allegiance : 2;
 	/* 03 */ u8  level	  : 5;
 
-	/* 04 */ u16 xPosition  : 6; /* 04:0 to 04:5 */
-	/* 04 */ u16 yPosition  : 6; /* 04:6 to 05:3 */
-	/* 05 */ u16 genMonster : 1; /* 05:4 */
-	/* 05 */ u16 itemDrop   : 1; /* 05:5 */
-	/* 05 */ u16 sumFlag	: 1; /* 05:6 */
-	/* 05 */ u16 extraData  : 9; /* 05:7 to 06:7 */
-	/* 07 */ u16 redaCount  : 8;
+	/* 04 */ u32 xPosition  : 6; /* 04:0 to 04:5 */
+	/* 04 */ u32 yPosition  : 6; /* 04:6 to 05:3 */
+	/* 05 */ u32 genMonster : 1; /* 05:4 */
+	/* 05 */ u32 itemDrop   : 1; /* 05:5 */
+	/* 05 */ u32 sumFlag	: 1; /* 05:6 */
+	/* 05 */ u32 extraData  : 9; /* 05:7 to 06:7 */
+	/* 07 */ u32 redaCount  : 8;
 
 	/* 08 */ const void* redas;
 


### PR DESCRIPTION
I hope it's okay that I make this PR. I noticed a small typo in `text.h` in the `TextHandle` struct. I also believe that the bitfield at 0x04 in the `UnitDefinition` struct should be `u32` instead of `u16`. As a `u16`, later fields would not be referenced correctly, but changing to `u32` seemed to fix the issue.